### PR TITLE
fix: Changes collection

### DIFF
--- a/src/Stores/DatabaseStore.php
+++ b/src/Stores/DatabaseStore.php
@@ -311,11 +311,14 @@ class DatabaseStore extends AbstractStore
             'deleted'  => [],
         ];
 
-        foreach ($this->newQuery()->pluck($this->keyColumn) as $key) {
-            if (Arr::has($changes['inserted'], $key))
-                $changes['updated'][$key] = $changes['inserted'][$key];
-            else
+        foreach ($this->newQuery()->pluck($this->valueColumn, $this->keyColumn) as $key => $value) {
+            if (Arr::has($changes['inserted'], $key)) {
+                if (Arr::get($changes['inserted'], $key) !== $value) {
+                    $changes['updated'][$key] = $changes['inserted'][$key];
+                }
+            } else {
                 $changes['deleted'][] = $key;
+            }
 
             Arr::forget($changes['inserted'], $key);
         }


### PR DESCRIPTION
This commit fixes an issue that occurs whilst gathering changes to save. Previously any "insert" change would be converted to an "update" because there was no values comparison. So if you have 10 000 settings in your DB and if you try to update only one setting - all of them would be updated over again, firing 10 000 DB requests as well. This change will collect only necessary changes excluding any unchanged values.